### PR TITLE
Fixes for audio init script & adding the missing talkplugin url

### DIFF
--- a/ts/5.1/packages/base/build/conf/10master
+++ b/ts/5.1/packages/base/build/conf/10master
@@ -153,11 +153,6 @@ ALLOW_EXIT=Off
 #                                   in Window Manager Main Menu
 #                           SUBMENU Places Icon on Desktop if package xtdesk is selected and
 #                                   in a Submenu within the window manager
-# SESSION_#_LAUNCH          Default is auto which is different behavior per package, choose between:
-#                               fullscreen
-#                               window
-#                               console
-#                               other - check in package/etc/cmd for more options for your package
 # SESSION_#_WORKSPACE       Workspace to run program on in a window manager
 # SESSION_#_type_SERVER     IP address/hostname of the server
 # SESSION_#_type_OPTIONS    Command line options for the session type

--- a/ts/5.1/packages/base/etc/init.d/session
+++ b/ts/5.1/packages/base/etc/init.d/session
@@ -9,7 +9,7 @@ let COLS=`echo $SCREEN_RESOLUTION | cut -f1 -dx`/6-1
 let ROWS=`echo $SCREEN_RESOLUTION | cut -f2 -dx`/14
 
 if is_enabled $X_RES_SEED; then
-        echo "SCREEN_RESOLUTION=\"$SCREEN_RESOLUTION\"" >>$TS_RUNTIME
+	echo "SCREEN_RESOLUTION=\"$SCREEN_RESOLUTION\"" >>$TS_RUNTIME
 fi
 
 echo "COLS=$COLS" >> $TS_RUNTIME
@@ -28,7 +28,6 @@ while [ $x -le $y ]; do
    SESSION_SCREEN=
    SESSION_SCREEN_POSITION=
    SESSION_ICON=
-   SESSION_LAUNCH=
    SESSION_CUSTOM_CONFIG=
 
    # Get Session details
@@ -40,7 +39,6 @@ while [ $x -le $y ]; do
    SESSION_SCREEN=`eval echo '$SESSION_'$x'_SCREEN'`
    SESSION_SCREEN_POSITION=`eval echo '$SESSION_'$x'_SCREEN_POSITION'`
    SESSION_ICON=`eval echo '$SESSION_'$x'_ICON'`
-   SESSION_LAUNCH=`eval echo '$SESSION_'$x'_LAUNCH'`
    SESSION_CUSTOM_CONFIG=`eval echo '$SESSION_'$x'_CUSTOM_CONFIG'`
 
    # Get package parameters
@@ -57,7 +55,6 @@ while [ $x -le $y ]; do
    if [ -z "$SERVER" ]; then SERVER=. ; fi
    if [ -z "$OPTIONS" ]; then OPTIONS=. ; fi
    if [ -z "$ICON" ]; then ICON=Off ; fi
-   if [ -z "$LAUNCH" ]; then LAUNCH=auto ; fi
    if [ -z "$SCREEN_POSITION" ]; then SCREEN_POSITION=1 ; fi
 
 
@@ -70,16 +67,15 @@ while [ $x -le $y ]; do
    if [ -z "$SESSION_SERVER" ] ;then SESSION_SERVER=$SERVER ; fi
    if [ -z "$SESSION_OPTIONS" ] ;then SESSION_OPTIONS=$OPTIONS ; fi
    if [ -z "$SESSION_ICON" ] ;then SESSION_ICON=$ICON ; fi
-   if [ -z "$SESSION_LAUNCH" ] ;then SESSION_LAUNCH=$LAUNCH ; fi
    if [ -e /etc/cmd/$SESSION_TYPE.change_server_type ] ; then
-        if [ -n "$SESSION_TITLE" ] ; then
-                SESSION_SERVER=`replace_char "$SESSION_TITLE" " " "_"`
-        elif [ -n "$SESSION_APPLICATION_SET" ] ;then
-                SESSION_SERVER=$SESSION_APPLICATION_SET
-                SESSION_TITLE=$SESSION_APPLICATION_SET
-        else
-                SESSION_SERVER="$SESSION_TYPE"_"$x"
-        fi
+	if [ -n "$SESSION_TITLE" ] ; then
+	   	SESSION_SERVER=`replace_char "$SESSION_TITLE" " " "_"`
+	elif [ -n "$SESSION_APPLICATION_SET" ] ;then
+		SESSION_SERVER=$SESSION_APPLICATION_SET
+		SESSION_TITLE=$SESSION_APPLICATION_SET
+	else
+		SESSION_SERVER="$SESSION_TYPE"_"$x"
+   	fi
    fi
    if [ -z "$SESSION_TITLE" ] ;then SESSION_TITLE=$SESSION_TYPE ; fi
    SESSION_AUTOSTART=`make_caps $SESSION_AUTOSTART`
@@ -88,24 +84,23 @@ while [ $x -le $y ]; do
    SESSION_CUSTOM_CONFIG=`make_caps $SESSION_CUSTOM_CONFIG`
 
    if [ "$SESSION_SCREEN_POSITION" != "1" ] ; then
-        if [ "$DUALHEAD" != "ENABLED" ] ; then
-           DUALHEAD=ENABLED
-           echo "DUALHEAD=$DUALHEAD" >> $TS_RUNTIME
-        fi
+   	if [ "$DUALHEAD" != "ENABLED" ] ; then
+	   DUALHEAD=ENABLED
+	   echo "DUALHEAD=$DUALHEAD" >> $TS_RUNTIME
+  	fi
    fi
    if [ -n "$SESSION_TYPE" ] ;then
      let y=y+1
      echo $SESSION_TYPE  \
-        `replace_invalid "$SESSION_TITLE"`  \
-        $SESSION_SCREEN  \
-        $SESSION_SCREEN_POSITION  \
-        $SESSION_WORKSPACE  \
-        $SESSION_AUTOSTART  \
-        $SESSION_CUSTOM_CONFIG  \
-        $SESSION_ICON  \
-        $SESSION_LAUNCH \
-        `replace_invalid "$SESSION_SERVER"`  \
-        `replace_invalid "$SESSION_OPTIONS"` >> $WKDIR/session
+	`replace_invalid "$SESSION_TITLE"`  \
+	$SESSION_SCREEN  \
+	$SESSION_SCREEN_POSITION  \
+	$SESSION_WORKSPACE  \
+	$SESSION_AUTOSTART  \
+	$SESSION_CUSTOM_CONFIG  \
+	$SESSION_ICON  \
+	`replace_invalid "$SESSION_SERVER"`  \
+	`replace_invalid "$SESSION_OPTIONS"` >> $WKDIR/session
    fi
 done
 
@@ -113,9 +108,8 @@ if [ ! -e $WKDIR/session ] ; then
   echo_log -d "\n\nError, no valid session type!!!"
   echo_log -d "Boot aborted, please check your thinstation config files are correct"
   if pkg_initialized debug ; then
-          echo_log -d "Debug Enabled...continuing"
+	  echo_log -d "Debug Enabled...continuing"
   else
-          halt
+	  halt
   fi
 fi
-

--- a/ts/5.1/packages/base/etc/init.d/session-setup
+++ b/ts/5.1/packages/base/etc/init.d/session-setup
@@ -4,68 +4,67 @@
 
 no_package()
 {
-        force_splash_exit
-        echo_log -n -d "ERROR: Package $type doesn't exist, aborting bootup. Check your "
-        echo_log -n -d "thinstation.conf file and build.conf file to make sure you have the "
-        echo_log -n -d "package loaded."
-        while true; do
-                sleep 10000
-        done
+	force_splash_exit
+	echo_log -n -d "ERROR: Package $type doesn't exist, aborting bootup. Check your "
+	echo_log -n -d "thinstation.conf file and build.conf file to make sure you have the "
+	echo_log -n -d "package loaded."
+	while true; do
+		sleep 10000
+	done
 }
 
 case "$1" in
 init)
-        if ! pkg_initialized $PACKAGE; then
-                pkg_set_init_flag $PACKAGE
-        fi
-        #Figure out if we have a window manager.
-        (cat $WKDIR/session) |
-        while read type title screen position workspace autostart custom icon launch server options ; do
-                if [ -e /etc/cmd/$type.wm ] && [ -z "$WMNAME" ] ; then
-                        echo "WMSCREEN=$screen" >> $TS_RUNTIME
-                        echo "WMNAME=$type" >> $TS_RUNTIME
-                        break
-                fi
-        done
+	if ! pkg_initialized $PACKAGE; then
+		pkg_set_init_flag $PACKAGE
+	fi
+	#Figure out if we have a window manager.
+	(cat $WKDIR/session) |
+	while read type title screen position workspace autostart custom icon server options ; do
+		if [ -e /etc/cmd/$type.wm ] && [ -z "$WMNAME" ] ; then
+			echo "WMSCREEN=$screen" >> $TS_RUNTIME
+			echo "WMNAME=$type" >> $TS_RUNTIME
+			break
+		fi
+	done
 
 . $TS_RUNTIME
 
-        #Now read the sessions for real and create our session script.
-        (cat $WKDIR/session) |
-        while read type title screen position workspace autostart custom icon launch server options ; do
-                autostart=`make_caps $autostart`
-                case $autostart in
-                        ON)
-                                if [ -e /etc/init.d/$type ]; then
-                                        # Set screen variables
-                                        export DISPLAY_NUMBER=$screen
-                                        export WMWORKSPACE=$workspace
-                                        export POSITION=$position
-                                        if [ "$server" = "." ] ; then server= ; fi
-                                        if [ "$options" = "." ] ; then options= ; fi
-                                        if [ ! -e /etc/console/$type ]; then
-                                                if [ -n "$WMNAME" ] && [ "$type" != "$WMNAME" ] && [ "$screen" == "$WMSCREEN" ] ; then
-                                                        echo "pkg $launch $type \"$server\" \"$options\" \"$WMWORKSPACE\" &" >> $WKDIR/$WMNAME.autostart
-                                                        echo "sleep .2" >> $WKDIR/$WMNAME.autostart
-                                                else
-                                                        echo "export DISPLAY_NUMBER=$DISPLAY_NUMBER" >> $WKDIR/windowapps
-                                                        echo "pkg console $type \"$server\" \"$options\" &" >> $WKDIR/windowapps
-                                                fi
-                                        else
-                                                echo "pkg console $type \"$server\" \"$options\"" >> $WKDIR/consoleapps
-                                        fi
-                                else
-                                        no_package
-                                fi
-                        ;;
-                        *)
-                                touch /tmp/BOOTMENU
-                        ;;
-                esac
-        done
+	#Now read the sessions for real and create our session script.
+	(cat $WKDIR/session) |
+	while read type title screen position workspace autostart custom icon server options ; do
+		autostart=`make_caps $autostart`
+		case $autostart in
+			ON)
+				if [ -e /etc/init.d/$type ]; then
+					# Set screen variables
+					export DISPLAY_NUMBER=$screen
+					export WMWORKSPACE=$workspace
+					export POSITION=$position
+					if [ "$server" = "." ] ; then server= ; fi
+					if [ "$options" = "." ] ; then options= ; fi
+					if [ ! -e /etc/console/$type ]; then
+						if [ -n "$WMNAME" ] && [ "$type" != "$WMNAME" ] && [ "$screen" == "$WMSCREEN" ] ; then
+							echo "pkg auto $type \"$server\" \"$options\" \"$WMWORKSPACE\" &" >> $WKDIR/$WMNAME.autostart
+							echo "sleep .2" >> $WKDIR/$WMNAME.autostart
+						else
+							echo "export DISPLAY_NUMBER=$DISPLAY_NUMBER" >> $WKDIR/windowapps
+							echo "pkg console $type \"$server\" \"$options\" &" >> $WKDIR/windowapps
+						fi
+					else
+						echo "pkg console $type \"$server\" \"$options\"" >> $WKDIR/consoleapps
+					fi
+				else
+					no_package
+				fi
+			;;
+			*)
+				touch /tmp/BOOTMENU
+			;;
+		esac
+	done
 ;;
 *)
-        exit
+	exit
 ;;
 esac
-


### PR DESCRIPTION
Fixed the audio init script & added the missing talkplugin url

The audio init script now tries to record from the default input device on boot, but only immediately opens the input and then closes it.  This prompts ALSA to create the "digital amplifier" device that is required for a working microphone on some models of Intel sound devices.
