### PR TITLE
use xz compression for fastboot

### DIFF
--- a/ts/5.1/fastboot/fastboot-mangle
+++ b/ts/5.1/fastboot/fastboot-mangle
@@ -58,7 +58,7 @@ if [ "$2" == "true" ] ; then
 	if [ "$HARDLINK" == "true" ]; then
 		hardlink -t -m lib
 	fi
-	../utils/tools/mksquashfs lib ../$INITDIR/lib.squash -always-use-fragments -no-recovery -all-root -no-xattrs -noappend
+	../utils/tools/mksquashfs lib ../$INITDIR/lib.squash -always-use-fragments -no-recovery -all-root -no-xattrs -noappend -comp xz -Xbcj x86 -Xdict-size 100%
 	for i in `ls --color=never lib/ |grep -Ewvf ../fastboot/lib-boot |grep -Ewv 'bin|sbin'` ; do
 		if [ ! -z "$i" ] ; then
 			rm -rf lib/$i


### PR DESCRIPTION
When building a images for memory-restricted systems (e.g. 128MB RAM or less), it's important to save space. Using xz compression instead of gzip significantly reduces the size of the fastboot squashfs, reducing the time needed to transfer it from the boot medium or TFTP server and saving lots of memory.
