### PR TITLE
Wrong path for wpa_supplicant bin

### DIFF
--- a/ts/5.1/packages/autonet/etc/udev/scripts/net.sh
+++ b/ts/5.1/packages/autonet/etc/udev/scripts/net.sh
@@ -136,7 +136,7 @@ _wlan()
 		exit
 	fi
 	if [ -n "$WIRELESS_WPAKEY" ];  then
-		if [ ! -x /bin/wpa_supplicant ]; then
+		if [ ! -x /sbin/wpa_supplicant ]; then
 			echo_log "Could not find wpa_supplicant"
 			exit
 		fi


### PR DESCRIPTION
wpa_supplicant binary lives in /sbin/ not /bin/ and as such the check for wpa_supplicant always fails. This change updates the path to replicate the wpa_supplicant package.
