### PR TITLE
some fixes for ts5.1 master branch

### DIFF
--- a/ts/5.1/build.urls
+++ b/ts/5.1/build.urls
@@ -8,7 +8,7 @@ param 2xurl             http://www.2x.com/downloads/AppServer-LoadBalancer/2XCli
 param tarantellaurl     file://home/installs/tnci3li.tar
 param chromeurl         https://dl.google.com/linux/direct/google-chrome-stable_current_i386.deb
 param eGalaxurl         http://210.64.17.162/web20/drivers/touch_driver/Linux/20120202/eGalaxTouch-3.07.6014-32b-k26.tar.gz
-param vmviewpcoipurl    https://launchpad.net/ubuntu/+archive/partner/+files/vmware-view-client_1.6.0.orig.tar.gz
+param vmviewpcoipurl    https://launchpad.net/ubuntu/+archive/partner/+files/vmware-view-client_2.1.0.orig.tar.gz
 param icaurl		file://downloads/linuxx86_12.1.0.203066.tar.gz
 param kioskurl		https://addons.cdn.mozilla.net/storage/public-staging/1659/r_kiosk-0.9.0-fx.xpi
 param javaurl		http://javadl.sun.com/webapps/download/AutoDL?BundleId=69465

--- a/ts/5.1/packages/automount/etc/udev/scripts/scsi.sh
+++ b/ts/5.1/packages/automount/etc/udev/scripts/scsi.sh
@@ -138,8 +138,9 @@ if [ "$TYPE" == "sr" ] && [ "$ACTION" == "change" ]; then
 		mount_opts="$CDROM_MOUNT_OPTIONS"
 		do_mounts
 	fi
-elif [ "$TYPE" == "sd" ] && [ "$ACTION" == "add" ] ; then
-	if [ "$ID_BUS" == "usb" ] ; then
+elif ( [ "$TYPE" == "sd" ] || [ "$TYPE" == "mm" ] ) && [ "$ACTION" == "add" ] ; then
+        if ( [ "$ID_BUS" == "usb" ] || [ "$TYPE" == "mm" ] ) ; then
+
 		if is_enabled $USB_STORAGE_SYNC && [ ! -n "`echo $USB_MOUNT_OPTIONS |grep -e sync`" ]; then
 			USB_MOUNT_OPTIONS=$USB_MOUNT_OPTIONS,sync
 		fi

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/128x128/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/128x128/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/16x16/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/16x16/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/22x22/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/22x22/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/24x24/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/24x24/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/256x256/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/256x256/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/32x32/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/32x32/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/48x48/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/48x48/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/64x64/apps/ica.png
+++ b/ts/5.1/packages/ica/build/extra/lib/icons/hicolor/64x64/apps/ica.png
@@ -1,0 +1,1 @@
+ica_wfc.png

--- a/ts/5.1/packages/vmviewpcoip/build/extra/bin/run_vmview
+++ b/ts/5.1/packages/vmviewpcoip/build/extra/bin/run_vmview
@@ -13,5 +13,10 @@ case $1 in
 esac
 shift
 done
+## udv scsi.sh script not allowed to mount if usb daemons of vmware are started
+touch /tmp/nomount
+## start vmware daemons.. just present in version 2.1 in version 2.2 they are missing..
+/lib/vmware/vmware-usbarbitrator
+/lib/vmware/vmware-view-usbd
 
 eval vmware-view $ARGS

--- a/ts/5.1/packages/wgetpaste/bin/uploadlogfiles.sh
+++ b/ts/5.1/packages/wgetpaste/bin/uploadlogfiles.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+### upload some simple files for debugging to pastebin
+### r.petry
+### version 1
+echo "starting" >/tmp/logfiles.date
+date=`date`
+
+echo "this file will upload some logfiles to pastebin. it will help to get support on the mailinglist" >>/tmp/logfiles.date
+echo "### lsmod ###" >>/tmp/logfiles.date
+lsmod >>/tmp/logfiles.date
+echo "### ifconfig ###" >>/tmp/logfiles.date
+ifconfig >>/tmp/logfiles.date
+if [ -e /bin/lspci ]
+then
+echo "#### lspci ### " >>/tmp/logfiles.date
+lspci >>/tmp/logfiles.date
+fi
+for name in "/etc/thinstation.network" "/var/log/*" "/var/log/net/*" "/etc/thinstation.defaults" "/var/run/applications/*"
+do
+#ls -l $name
+echo "###### FILE ### $name #####" >>/tmp/logfiles.date
+cat $name >>/tmp/logfiles.date
+done
+echo " #### packages ####" >>/tmp/logfiles.date
+ls -l /var/packages >>/tmp/logfiles.date


### PR DESCRIPTION
- ica session icon not linked
- mount of mmc devices ( internal card readers )
- vmwareview url´s fixed for 2.1 client with usb support - version 2.2 doesnt provide the usb daemons..we stay on 2.1
- first release of a log collector

bye
roman
