### PR TITLE
Openkiosk links missing in the repository

### DIFF
--- a/ts/5.1/packages/openkiosk/bin/openkiosk
+++ b/ts/5.1/packages/openkiosk/bin/openkiosk
@@ -1,0 +1,1 @@
+/lib/openkiosk/openkiosk

--- a/ts/5.1/packages/openkiosk/etc/rc2.d/S10openkiosk.init
+++ b/ts/5.1/packages/openkiosk/etc/rc2.d/S10openkiosk.init
@@ -1,0 +1,1 @@
+/etc/init.d/openkiosk.init


### PR DESCRIPTION
Somehow these links didn't get pulled into git:

 ts/5.1/packages/openkiosk/bin/openkiosk -> /lib/openkiosk/openkiosk
 ts/5.1/packages/openkiosk/etc/rc2.d/S10openkiosk.init -> /etc/init.d/openkiosk.init
