### PR TITLE
Update run_vmview

### DIFF
--- a/ts/5.2/packages/vmviewpcoip/build/extra/bin/run_vmview
+++ b/ts/5.2/packages/vmviewpcoip/build/extra/bin/run_vmview
@@ -13,10 +13,5 @@ case $1 in
 esac
 shift
 done
-## udv scsi.sh script not allowed to mount if usb daemons of vmware are started
-touch /tmp/nomount
-## start vmware daemons.. just present in version 2.1 in version 2.2 they are missing..
-/lib/vmware/vmware-usbarbitrator
-/lib/vmware/vmware-view-usbd
 
 eval vmware-view $ARGS


### PR DESCRIPTION
Thinstation uses version 2.2 of vmware-view and that version doesn't have usb mounting daemons. These lines were deleted in https://github.com/Thinstation/thinstation/pull/42 , but they came back :)
