### PR TITLE
Change vmviewpcoip url

### DIFF
--- a/ts/build/build.urls
+++ b/ts/build/build.urls
@@ -8,7 +8,7 @@ param 2xurl             http://www.2x.com/downloads/AppServer-LoadBalancer/2XCli
 param tarantellaurl     file://downloads/tnci3li.tar
 param chromeurl         https://dl.google.com/linux/direct/google-chrome-stable_current_i386.deb
 param egalaxurl         http://www.eeti.com.tw/touch_driver/Linux/20141009/eGTouch_v2.5.4330.L-x.zip
-param vmviewpcoipurl    file://downloads/VMware-Horizon-Client-3.2.0-2331566.x86.bundle
+param vmviewpcoipurl    https://download3.vmware.com/software/view/viewclients/CART14Q4/VMware-Horizon-Client-3.2.0-2331566.x86.bundle
 param icaurl		file://downloads/linuxx86-13.1.0.285639.tar.gz
 param kioskurl		https://addons.cdn.mozilla.net/storage/public-staging/1659/r_kiosk-0.9.0-fx.xpi
 param javaurl		http://javadl.sun.com/webapps/download/AutoDL?BundleId=101398


### PR DESCRIPTION
Original URL was a local file and failed to build. Added the latest location of the binary.