### PR TITLE
update ccid and rdesktop version + lprng bug

### DIFF
--- a/ts/build/packages/lprng/etc/init.d/lprng
+++ b/ts/build/packages/lprng/etc/init.d/lprng
@@ -48,8 +48,9 @@ init)
 	lpd
 	sleep 1
 
-	chmod 666 /dev/printers
-
+	chmod 666 /dev/lp0
+	chmod 666 /dev/usb/lp0
+	
 	pkg_set_init_flag $PACKAGE
     fi
     ;;

--- a/ts/ports/components/ccid/Pkgfile
+++ b/ts/ports/components/ccid/Pkgfile
@@ -6,7 +6,7 @@
 name=ccid
 version=1.4.18
 release=1
-source=(https://alioth.debian.org/frs/download.php/file/4111/$name-$version.tar.bz2)
+source=(https://alioth.debian.org/frs/download.php/file/4132/$name-$version.tar.bz2)
 
 build() {
 	cd $name-$version

--- a/ts/ports/components/ccid/Pkgfile
+++ b/ts/ports/components/ccid/Pkgfile
@@ -4,7 +4,7 @@
 # depends on: pcsc-lite-TS
 
 name=ccid
-version=1.4.18
+version=1.4.19
 release=1
 source=(https://alioth.debian.org/frs/download.php/file/4132/$name-$version.tar.bz2)
 

--- a/ts/ports/contrib/rdesktop/Pkgfile
+++ b/ts/ports/contrib/rdesktop/Pkgfile
@@ -4,7 +4,7 @@
 # Depends on: xorg-libx11
 
 name=rdesktop
-version=1.8.2
+version=1.8.3
 release=1
 source=(http://download.sourceforge.net/rdesktop/$name-$version.tar.gz)
 build(){


### PR DESCRIPTION
Can  you update rdesktop and ccid versions to latest?
Also add a bug with permissions on lprng  usb and parallel printers
It will be interesint in thinstation.conf.builtime update /dev/printers/0 to new device in thinstation 5  /dev/lp0

Thanks