### PR TITLE
disable clear

### DIFF
--- a/ts/build/packages/base/etc/profile
+++ b/ts/build/packages/base/etc/profile
@@ -24,7 +24,7 @@ if [ "`tty`" == "$CONSOLE" ]; then
 	elif [ -e /bin/xinit ] && [ -e $WKDIR/windowapps ]; then
 		if check_last_session; then
 			cd /var/run
-			clear
+#			clear
 			splash_exit
 			exec /bin/xinit /etc/xinitrc -- /etc/xserverrc > /var/run/applications/session.$$ 2>&1
 		elif ! is_enabled $HALTONERROR; then


### PR DESCRIPTION
With thinstation 2.2 clear was enalbed and it is a great option to view boot messages