### PR TITLE
Typo in xfwm4.functions

### DIFF
--- a/ts/build/packages/xfwm4/build/extra/etc/xfwm4.functions
+++ b/ts/build/packages/xfwm4/build/extra/etc/xfwm4.functions
@@ -46,7 +46,7 @@ xfconf_settings()
 	else
 		xfconf-query -c xfce4-desktop -p /desktop-icons/file-icons/show-trash -t bool -s true -n
 	fi
-	if is_disabled $DEKSTOP_SHOWHOME; then
+	if is_disabled $DESKTOP_SHOWHOME; then
 		xfconf-query -c xfce4-desktop -p /desktop-icons/file-icons/show-home -t bool -s false -n
 	else
 		xfconf-query -c xfce4-desktop -p /desktop-icons/file-icons/show-home -t bool -s true -n


### PR DESCRIPTION
Variable DESKTOP_SHOWHOME was not honored due to a typo.