### PR TITLE
correct path for sda devices, detect part

### DIFF
--- a/ts/build/packages/hdupdate/etc/init.d/hdupdate
+++ b/ts/build/packages/hdupdate/etc/init.d/hdupdate
@@ -72,7 +72,15 @@ init)
        do
          for CURRENT_PART in ${PARTITION_LIST}
          do
-           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+##           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+
+         if [ "${CURRENT_DISK}" = "/mnt/disc/sda" ] ; then
+          HDCHECK="${CURRENT_DISK}/part${CURRENT_PART}/boot"
+         else
+          HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+         fi
+
+
            echo_log "Checking for vmlinuz on ${HDCHECK}"
            if [ -e ${HDCHECK}/vmlinuz ] ; then
              echo_log "vmlinuz found at ${HDCHECK}"


### PR DESCRIPTION
sda path would be /mnt/disc/sda{partition} and now is /mnt/disc/sda/part{partition}, added support.

correct path should be /mnt/disc/sda{partition} but I don't know where to configure to remove part