### PR TITLE
Changes to HDUPDATE

### DIFF
--- a/ts/build/packages/hdupdate/etc/init.d/hdupdate
+++ b/ts/build/packages/hdupdate/etc/init.d/hdupdate
@@ -4,7 +4,7 @@
 . /etc/splash.functions
 
   ##DISKMNT="/mnt/disc/sda"
-  DISK_LIST="/mnt/disc/sda /mnt/mnt/usbdevice/sda /mnt/mnt/usbdevice/mmcblk0p"
+  DISK_LIST="/mnt/disc/sda /mnt/usbdevice/sda /mnt/usbdevice/mmcblk0p"
   PARTITION_LIST="1 2 3 4"
   let progress=0
   let splash_total=20
@@ -79,7 +79,7 @@ init)
 #           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
          if [ "${CURRENT_DISK}" = "/mnt/disc/sda" ] ; then
           HDCHECK="${CURRENT_DISK}/part${CURRENT_PART}/boot"
-         else if [ "${CURRENT_DISK}" = "/mnt/mnt/usbdevice/mmcblk0p" ] ; then
+         else if [ "${CURRENT_DISK}" = "/mnt/usbdevice/mmcblk0p" ] ; then
           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
           else
           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"


### PR DESCRIPTION
changed the double "/mnt" path for mmc devices and  usb devices. Did this changes on my local install of TS and they worked out.