### PR TITLE
incorrect path in hdupdate

### DIFF
--- a/ts/build/packages/hdupdate/etc/init.d/hdupdate
+++ b/ts/build/packages/hdupdate/etc/init.d/hdupdate
@@ -72,7 +72,6 @@ init)
       fi
 
 # Determine temporary filesystem to use
-
       if [ "`make_caps $HDUPDATE_TEMP`" = "RAM" ] ; then
         	TEMPPATH="/tmp"
       else

--- a/ts/build/packages/hdupdate/etc/init.d/hdupdate
+++ b/ts/build/packages/hdupdate/etc/init.d/hdupdate
@@ -3,7 +3,8 @@
 . $TS_GLOBAL
 . /etc/splash.functions
 
-  DISKMNT="/mnt/disc/sda"
+  ##DISKMNT="/mnt/disc/sda"
+  DISK_LIST="/mnt/disc/sda /mnt/usbdevice/sda /mnt/usbdevice/mmcblk0p"
   PARTITION_LIST="1 2 3 4"
   let progress=0
   let splash_total=20
@@ -11,6 +12,9 @@
   if [ -n "$DEBUG_NETWORK" ] ; then
           debug="-d"
   fi
+
+  echo_log " " $debug
+  echo_log "  HDUPDATE WS Version: ${HDUPDATE_WS_VERSION}" $debug
 
 case "$1" in
 init)
@@ -50,20 +54,50 @@ init)
       echo_log "  New version:     ${HDUPDATE_SERVER_VERSION}" $debug
 
 # Search local hard ide disk for existing vmlinuz
-      HDTARGET="NONE"
-      for CURRENT_PART in ${PARTITION_LIST}
-      do
-        HDCHECK="${DISKMNT}/part${CURRENT_PART}"
-        echo_log "Checking for vmlinuz on ${HDCHECK}"
-        if [ -e ${HDCHECK}/vmlinuz ] ; then
-          echo_log "vmlinuz found at ${HDCHECK}"
-          HDTARGET="${HDCHECK}"
-        fi
-      done
-      if [ "${HDTARGET}" = "NONE" ] ; then
-        echo_log "Update failed, target drive not found\n" $debug
-        exit 0
-      fi 
+##      HDTARGET="NONE"
+##      for CURRENT_PART in ${PARTITION_LIST}
+##      do
+##        HDCHECK="${DISKMNT}/part${CURRENT_PART}/boot"
+##        echo_log "Checking for vmlinuz on ${HDCHECK}"
+##        if [ -e ${HDCHECK}/vmlinuz ] ; then
+##          echo_log "vmlinuz found at ${HDCHECK}"
+##          HDTARGET="${HDCHECK}"
+##        fi
+##      done
+##      if [ "${HDTARGET}" = "NONE" ] ; then
+##        echo_log "Update failed, target drive not found\n" $debug
+##        exit 0
+##      fi 
+
+# Search local hard disk (sata/usbdevice) for existing vmlinuz
+       HDTARGET="NONE"
+       for CURRENT_DISK in ${DISK_LIST}
+       do
+         for CURRENT_PART in ${PARTITION_LIST}
+         do
+
+#           HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+         if [ "${CURRENT_DISK}" = "/mnt/disc/sda" ] ; then
+          HDCHECK="${CURRENT_DISK}/part${CURRENT_PART}/boot"
+         else if [ "${CURRENT_DISK}" = "/mnt/usbdevice/mmcblk0p" ] ; then
+          HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+          else
+          HDCHECK="${CURRENT_DISK}${CURRENT_PART}/boot"
+          fi
+         fi
+
+           echo_log "Checking for vmlinuz on ${HDCHECK}"
+           if [ -e ${HDCHECK}/vmlinuz ] ; then
+             echo_log "vmlinuz found at ${HDCHECK}"
+             HDTARGET="${HDCHECK}"
+           fi
+         done
+       done
+       if [ "${HDTARGET}" = "NONE" ] ; then
+         echo_log "Update failed, target drive not found\n" $debug
+         exit 0
+       fi
+
 
 # found the local file location
 # now download to a temp location
@@ -72,6 +106,7 @@ init)
       fi
 
 # Determine temporary filesystem to use
+
       if [ "`make_caps $HDUPDATE_TEMP`" = "RAM" ] ; then
         	TEMPPATH="/tmp"
       else
@@ -93,7 +128,7 @@ init)
         case `make_caps ${HDUPDATE_SERVER_TYPE}` in
 		TFTP)
         		TYPE_RETURN=0
-        		( tftp -g -l ${TEMPFILE} -r ${SOURCEFILE} ${HDUPDATE_SERVER} ; echo $? > /tmp/return ) &
+        		( tftp -g -l ${TEMPFILE} -r ${SOURCEFILE} -b ${TFTP_BLOCKSIZE} ${HDUPDATE_SERVER} ; echo $? > /tmp/return ) &
 			while pidof tftp > /dev/null; do
 				echo_log "." -n $debug
 				let progress=progress+1


### PR DESCRIPTION
Please revert to previous version hdupdate file 
Thinstation@8c55f73

Tested with latest versions and usbdevice is mounted with 
ts:~# df -h
Filesystem                Size      Used Available Use% Mounted on
rootfs                 1007.1M    772.0K   1006.3M   0% /
/dev/root                76.3M     76.3M         0 100% /oldroot
tmpfs                  1007.1M    772.0K   1006.3M   0% /oldroot/mnt/dynamic
none                   1007.1M    772.0K   1006.3M   0% /
dev                     968.7M         0    968.7M   0% /dev
tmpfs                  1007.1M     32.0K   1007.0M   0% /tmp
tmpfs                  1007.1M     72.0K   1007.0M   0% /dev/shm
/dev/sda1               979.1M     80.3M    898.9M   8% /mnt/mnt/usbdevice/sda1

Not /mnt/usbdevice/sda1

Thanks