### PR TITLE
Xorg glamoregl dynamically depends on libEGL

### DIFF
--- a/ts/build/packages/xorg7-glamor/.dna
+++ b/ts/build/packages/xorg7-glamor/.dna
@@ -1,2 +1,3 @@
-xorg-server,libglamoregl.so,0,0,lib/xorg/modules,1,,,,,,,,,
 ,dependencies,0,0,,0,,,,,,,,,
+mesa3d,libEGL.so.1.0.0,10,0,lib,1,lib/libEGL.so.1,,,,,,,,
+xorg-server,libglamoregl.so,0,0,lib/xorg/modules,1,,,,,,,,,

--- a/ts/unwind_cache/xorg7-glamor.turbo
+++ b/ts/unwind_cache/xorg7-glamor.turbo
@@ -1,4 +1,7 @@
-#ffd3cdac33a52ca84590893ee64cff0b  .dna
+#40425e31ca7f8986c0494dfa31e80970  .dna
 
+mkdir -p /ts/build/packages/xorg7-glamor/lib
 mkdir -p /ts/build/packages/xorg7-glamor/lib/xorg/modules
+ln /usr/lib/libEGL.so.1.0.0 /ts/build/packages/xorg7-glamor/lib/.
 ln /usr/lib/xorg/modules/libglamoregl.so /ts/build/packages/xorg7-glamor/lib/xorg/modules/.
+ln -sf libEGL.so.1.0.0 /ts/build/packages/xorg7-glamor/lib/libEGL.so.1

--- a/ts/wind_cache/xorg7-glamor.turbo
+++ b/ts/wind_cache/xorg7-glamor.turbo
@@ -1,3 +1,5 @@
-#ffd3cdac33a52ca84590893ee64cff0b  .dna
+#40425e31ca7f8986c0494dfa31e80970  .dna
+rm /ts/build/packages/xorg7-glamor/lib/libEGL.so.1.0.0
+rm -f /ts/build/packages/xorg7-glamor/lib/libEGL.so.1
 rm /ts/build/packages/xorg7-glamor/lib/xorg/modules/libglamoregl.so
 


### PR DESCRIPTION
glamoregl is needed for Southern Island and other Radeon; optional for others