### PR TITLE
add doc related how to configure cups printers on boot (usb, lpt and network printers)

### DIFF
--- a/ts/build/conf/cups_printer.conf.sample
+++ b/ts/build/conf/cups_printer.conf.sample
@@ -1,0 +1,31 @@
+##
+# --- LPR Printing Options
+#
+# CUPS_PRINTER_0_NAME     Workstation Printer Name, Can be Any Valid Name
+#                    If you have turned ICA_PRINTER=ON then this is the 
+#                    name of the printer driver
+# CUPS_PRINTER_0_DEVICEURI   Workstation printer device (if not specified devices
+#                    are not loaded).
+#                       file:///dev/lp[0-2]   for parallel ports
+#                       file:///dev/usb/lp[0-2] for USB printers
+#                       socket://ip_address for network printers
+#
+# CUPS_PRINTER_1_*        See CUPS_PRINTER_0_*
+# CUPS_PRINTER_2_*        See CUPS_PRINTER_0_*
+# CUPS_PRINTER_3_*        See CUPS_PRINTER_0_*
+
+ # If having trouble with autocreate, keep the name "CUPS_PRINTER_?_NAME" under 15 characters & don't use spaces 
+#Example network printer
+#CUPS_PRINTER_0_NAME="sample network printer 0"
+#CUPS_PRINTER_0_DEVICEURI="socket://ip_address"
+#CUPS_PRINTER_0_DRIVER="drv:///sample.drv/generpcl.ppd"
+
+#Example usb printer
+#CUPS_PRINTER_1_NAME="sample usb printer 1"
+#CUPS_PRINTER_1_DEVICEURI="file:///dev/usb/lp0"
+#CUPS_PRINTER_1_DRIVER="drv:///sample.drv/generpcl.ppd"
+
+#Example lpt printer
+#CUPS_PRINTER_2_NAME="sample lpt printer 2"
+#CUPS_PRINTER_2_DEVICEURI="file:///dev/lp0"
+#CUPS_PRINTER_2_DRIVER="drv:///sample.drv/generpcl.ppd"

--- a/ts/build/conf/cups_printer.conf.sample
+++ b/ts/build/conf/cups_printer.conf.sample
@@ -6,9 +6,14 @@
 #                    name of the printer driver
 # CUPS_PRINTER_0_DEVICEURI   Workstation printer device (if not specified devices
 #                    are not loaded).
+#
+#                     Requirement:
+#                     FileDevice Yes in cupsd.conf  (by default enabled in thinstation) 
+#
 #                       file:///dev/lp[0-2]   for parallel ports
 #                       file:///dev/usb/lp[0-2] for USB printers
 #                       socket://ip_address for network printers
+#                      
 #
 # CUPS_PRINTER_1_*        See CUPS_PRINTER_0_*
 # CUPS_PRINTER_2_*        See CUPS_PRINTER_0_*

--- a/ts/build/packages/cups/build/extra/etc/init.d/cups
+++ b/ts/build/packages/cups/build/extra/etc/init.d/cups
@@ -10,6 +10,7 @@ init)
     if ! pkg_initialized $PACKAGE; then
       pkg_set_init_flag $PACKAGE
 
+        # Requirement for cups printing to /dev/usb/lp0 and /dev/lp0 (filedevices)
         echo "FileDevice yes" >> /etc/cups/cupsd.conf
 
       /sbin/cupsd


### PR DESCRIPTION
some examples and doc + wiki updated (https://github.com/Thinstation/thinstation/wiki/Printer-configuration)