### PR TITLE
changed execution of hwclock to be executed at minute 2

### DIFF
--- a/ts/build/packages/ntp/etc/init.d/ntpd
+++ b/ts/build/packages/ntp/etc/init.d/ntpd
@@ -32,7 +32,7 @@ start ()
 		if [ -n "$tickers" ]; then
 			echo "1 * * * * /etc/init.d/ntpd restart" >> /tmp/crontab
 			if is_enabled $RTC_CMOS_UPDATE; then
-				echo "1 * * * * hwclock -w" >> /tmp/crontab
+				echo "2 * * * * hwclock -w" >> /tmp/crontab
 				if is_enabled $WAIT_FOR_TOCK; then
 					ntpdate -s -b $tickers
 				fi


### PR DESCRIPTION
This pull request fixes a minor problem with hwclock being executed to early if retrieving the time from an ntp does take to long. Now hwclock will be executed one minute after reissuing an ntp request to be in time.