### PR TITLE
added --log-target=syslog to pulseaudio xinit call

### DIFF
--- a/ts/build/packages/pulseaudio/build/extra/etc/X11/xinit/xinitrc.d/pulseaudio
+++ b/ts/build/packages/pulseaudio/build/extra/etc/X11/xinit/xinitrc.d/pulseaudio
@@ -1,1 +1,1 @@
-/bin/pulseaudio --start
+/bin/pulseaudio --start --log-target=syslog


### PR DESCRIPTION
This pull request adds "--log-target=syslog" to the xinit pulseaudio call to make sure pulseaudio logs everything to syslog accordingly.