### PR TITLE
minor fixes/modifications to ts/build/build script

### DIFF
--- a/ts/build/build
+++ b/ts/build/build
@@ -995,7 +995,7 @@ do
 		done
 	fi
 	if [ `make_caps X$args` == "XFORCE" ]; then
-		echo $name `echo $args | cut -f1 -d#` >> ./tmp-tree/etc/modules
+		echo $name >> ./tmp-tree/etc/modules
 	fi
 	;;
     module_pkg)
@@ -1523,7 +1523,7 @@ for filename in `ls -1 $PKGDIR/` ; do
 		rm -Rf build
 	fi
 	echo "Building $filename.pkg"
-	tar -cz * > ../$filename.pkg
+	tar -cJf ../$filename.pkg *
 	cd ../../..
 	rm -Rf $PKGDIR/$filename
 	if [ -n "$PKGFILES" ] ; then


### PR DESCRIPTION
This pull request fixes/integrates two minor changes to the ts/build/build script where the first modification fixes the extraction of the module name in case the FORCE option is specified in build.conf files. The second minor modifications changes to bz2 compression use for generating external packages so that their size is significantly reduces for downloading them on every thinstation boot up.

Please note that the github shown diff output on the github webpages seems to be incorrect (Github bug?) as the line numbers don't mach exactly!