### PR TITLE
Fix ownership for NetworkManager dispatcher scripts

### DIFF
--- a/ts/build/packages/networkmanager/build/finalize
+++ b/ts/build/packages/networkmanager/build/finalize
@@ -1,2 +1,3 @@
 #networkmanager 75
 echo "/bin/nm-applet &" >> /etc/skel/.xinitrc
+chown root:root /etc/NetworkManager/dispatcher.d/00-update-status

--- a/ts/build/packages/ntp/build/finalize
+++ b/ts/build/packages/ntp/build/finalize
@@ -1,2 +1,3 @@
 #ntp 35
 chmod 640 /etc/ntp.conf
+chown root:root /etc/NetworkManager/dispatcher.d/90-ntp


### PR DESCRIPTION
When repository is cloned by unprivileged user, files `/etc/NetworkManager/dispatcher.d/00-update-status` and `/etc/NetworkManager/dispatcher.d/90-ntp` are owned by this user. But this cause errors:

```
nm-dispatcher.action: Cannot execute '/etc/NetworkManager/dispatcher.d/00-update-status': not owned by root.
nm-dispatcher.action: Cannot execute '/etc/NetworkManager/dispatcher.d/90-ntp': not owned by root.
```

Ownership should be fixed on building stage.