### PR TITLE
update freerdp, pcsc and ccid to latest versions to solve some bugs + vnc bug - TS5.4

### DIFF
--- a/ts/build/packages/xorg7vnc/bin/check_x11vnc
+++ b/ts/build/packages/xorg7vnc/bin/check_x11vnc
@@ -1,8 +1,7 @@
 #!/bin/sh
 if [ -z "`pidof x11vnc`" ]; then
-  /usr/bin/x11vnc -forever -rfbport 5900 -rfbauth /home/tsuser/.vnc/passwd -o /var/log/x11vnc &
-  ##x11vnc -forever  -q -usepw -httpdir /lib/www/html/x11vnc -o /var/log/x11vnc &
+  x11vnc -forever  -q -usepw -httpdir /lib/www/html/x11vnc -o /var/log/x11vnc &
   # Now we have got it started stop this cron nonsense:
-  sed -i s/"*\/1 \* \* \* \* \/bin\/check_x11vnc"// /tmp/crontab
+##  sed -i s/"*\/1 \* \* \* \* \/bin\/check_x11vnc"// /tmp/crontab
   crontab /tmp/crontab
 fi

--- a/ts/build/packages/xorg7vnc/bin/check_x11vnc
+++ b/ts/build/packages/xorg7vnc/bin/check_x11vnc
@@ -1,6 +1,7 @@
 #!/bin/sh
 if [ -z "`pidof x11vnc`" ]; then
-  x11vnc -forever  -q -usepw -httpdir /lib/www/html/x11vnc -o /var/log/x11vnc &
+  /usr/bin/x11vnc -forever -rfbport 5900 -rfbauth /home/tsuser/.vnc/passwd -o /var/log/x11vnc &
+  ##x11vnc -forever  -q -usepw -httpdir /lib/www/html/x11vnc -o /var/log/x11vnc &
   # Now we have got it started stop this cron nonsense:
   sed -i s/"*\/1 \* \* \* \* \/bin\/check_x11vnc"// /tmp/crontab
   crontab /tmp/crontab

--- a/ts/ports/components/ccid/Pkgfile
+++ b/ts/ports/components/ccid/Pkgfile
@@ -4,9 +4,9 @@
 # depends on: pcsc-lite-TS
 
 name=ccid
-version=1.4.19
+version=1.4.26
 release=1
-source=(https://alioth.debian.org/frs/download.php/file/4132/$name-$version.tar.bz2)
+source=(https://alioth.debian.org/frs/download.php/file/4205/$name-$version.tar.bz2
 
 build() {
 	cd $name-$version

--- a/ts/ports/components/pcsc-lite/Pkgfile
+++ b/ts/ports/components/pcsc-lite/Pkgfile
@@ -3,9 +3,9 @@
 # Maintainer: Donald A. Cupp Jr. (don cupp jr at ya hoo dot com)
 
 name=pcsc-lite
-version=1.8.13
+version=1.8.20
 release=1
-source=(https://alioth.debian.org/frs/download.php/file/4126/$name-$version.tar.bz2)
+source=(https://alioth.debian.org/frs/download.php/file/4203/$name-$version.tar.bz2)
 
 build() {
 	cd $name-$version

--- a/ts/ports/opt/freerdp/Pkgfile
+++ b/ts/ports/opt/freerdp/Pkgfile
@@ -4,12 +4,11 @@
 # Depends on: xorg-libx11
 
 name=freerdp
-version=2.0-dev-20160408_git_45ab979
-release=45ab97904f862eb336e92caf3ed5759c23404b19
+version=2.0-dev
+release=master
 
 build() {
-	git clone git://github.com/FreeRDP/FreeRDP.git -o ${release}
-#	git clone git://github.com/FreeRDP/FreeRDP.git -b ${release}
+	git clone git://github.com/FreeRDP/FreeRDP.git -b ${release}
 	cd FreeRDP
 	cmake .	-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \


### PR DESCRIPTION
Don,

Latest freerdp, pcscd and ccidreader contains many improvements, some related with importants smartcard disconnections with windows 2012r2
Can you rebuild this 3 packages to TS 5.4 and TS 5.5

