### PR TITLE
Added package autoruns

### DIFF
--- a/ts/build/build.conf.example
+++ b/ts/build/build.conf.example
@@ -319,6 +319,8 @@ package set-resolution		# Allows the user to change the resolution via the start
                             #     Web- or TFTP-server when it booted.
 #package hdd-spindown		# Sets hard drives into sleep mode (spin down) when they are idle. See thinstation.conf.sample for info.
 #package openssl             # Probably needed by the Citrix Receiver 13.2 version.
+#package autoruns            # Package that during boot runs scripts/commands defined in thinstation.conf.xxx files.
+
 
 
 # Parameters

--- a/ts/build/packages/autoruns/bin/autoruns
+++ b/ts/build/packages/autoruns/bin/autoruns
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+. /etc/thinstation.env
+. $TS_GLOBAL
+
+LOGGERTAG="autoruns"
+
+
+runCommand()
+{
+    let x=0
+    #echo "`eval echo '$'${1}'_'$x`"
+
+    while [ -n "`eval echo '$'${1}'_'$x`" ] ; do
+        # grab the command into a variable
+        cmd=`eval echo '$'${1}'_'$x`
+        
+        logger --stderr --tag $LOGGERTAG "runCommand: Executing '${1}_$x' command: '$cmd'"
+
+        # execute the command
+        $cmd
+
+        let x=x+1
+    done
+}
+
+#####
+# Main script
+##
+
+
+case "$1" in
+
+    rc5)
+        runCommand AUTORUNS_RC5
+    ;;
+
+
+
+    xfce)
+        runCommand AUTORUNS_XFCE
+    ;;
+
+
+
+    *)
+        echo "Runs commands stored in variables AUTORUNS_<type>_<x> where <type> is either RC5 or XFCE and <x> is count from 0"
+        echo "Example of variables in thinstation.conf.network: AUTORUNS_XFCE_0=\"My_command_to_execute\""
+        echo "Usage: $0 {rc5|xfce}"
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/ts/build/packages/autoruns/build/conf/90autoruns
+++ b/ts/build/packages/autoruns/build/conf/90autoruns
@@ -1,0 +1,15 @@
+
+# Autoruns - a package to run commands defined in thinstation.conf.xxx files at startup
+#
+# AUTORUNS_RC5_x            Runs commands during rc5 init process with priority S99
+#
+# AUTORUNS_XFCE_x           Runs commands in Xfce when it starts. Use this if your command
+#                           only works in a Xfce session.
+#
+#Examples:
+#   AUTORUNS_RC5_0="my_first_command"
+#   AUTORUNS_RC5_1="my_second_command"
+#
+#   AUTORUNS_XFCE_0="my_first_command_run_inside_X-window"
+#   AUTORUNS_XFCE_1="my_second_command_run_inside_X-window"
+#

--- a/ts/build/packages/autoruns/etc/init.d/autoruns.init
+++ b/ts/build/packages/autoruns/etc/init.d/autoruns.init
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+. $TS_GLOBAL
+
+case "$1" in  
+    init)
+        /bin/autoruns rc5
+    ;;
+
+
+    *)
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/ts/build/packages/autoruns/etc/rc5.d/S99autoruns.init
+++ b/ts/build/packages/autoruns/etc/rc5.d/S99autoruns.init
@@ -1,0 +1,1 @@
+/etc/init.d/autoruns.init

--- a/ts/build/packages/autoruns/etc/xdg/autostart/autoruns.desktop
+++ b/ts/build/packages/autoruns/etc/xdg/autostart/autoruns.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=autoruns
+Comment=Runs startup scripts for the autoruns package
+TryExec=/bin/autoruns
+Exec=/bin/autoruns xfce
+StartupNotify=false
+Terminal=false
+Type=Application
+Icon=ica
+Categories=GTK;GNOME;X-Xfce-Toplevel;


### PR DESCRIPTION
Added a new packge "autoruns" that during boot time runs commands defined in the thinstation.conf.xxx files. Runs as rc5 S99 and also as a xfce autostart script.

This packages helps fixing minor configuration issues without needing to rebuild and deploying the whole image.