### PR TITLE
Update freerdp.init to use known_hosts2 instead of known_hosts

### DIFF
--- a/ts/build/packages/freerdp/build/extra/etc/init.d/freerdp.init
+++ b/ts/build/packages/freerdp/build/extra/etc/init.d/freerdp.init
@@ -15,7 +15,7 @@ init)
 	fi
 	CNT=0
 	while [ -n "`eval echo '$FREERDP_KNOWN_HOST_'$CNT`" ]; do
-		echo "`eval echo '$FREERDP_KNOWN_HOST_'$CNT`" >> $HOME/.config/freerdp/known_hosts
+		echo "`eval echo '$FREERDP_KNOWN_HOST_'$CNT`" >> $HOME/.config/freerdp/known_hosts2
 		let CNT=CNT+1
 	done
 	pkg_set_init_flag $PACKAGE


### PR DESCRIPTION
FreeRDP currently uses known_hosts2 instead of known_hosts, known_hosts is regarded legacy.
https://github.com/FreeRDP/FreeRDP/commit/b43c9f9060a6fa3f8a37a4958f2c3682b2c563c0
https://github.com/FreeRDP/FreeRDP/commit/619223073791fc0270eb9ea531b7823792abfc27