### PR TITLE
Fixed openvpn binary and config file locations in init script

### DIFF
--- a/ts/build/packages/openvpn/build/extra/etc/init.d/openvpn
+++ b/ts/build/packages/openvpn/build/extra/etc/init.d/openvpn
@@ -2,7 +2,7 @@
 
 . $TS_GLOBAL
 
-case "$1" in  
+case "$1" in
 init)
     if ! pkg_initialized $PACKAGE; then
 	pkg_set_init_flag $PACKAGE
@@ -27,10 +27,10 @@ init)
 		cat client.tpl | sed -f /tmp/script  > client.conf
 		rm /tmp/script
 		if  [ ! -z "$OPENVPN_PROXY" ] && [ ! -z "$OPENVPN_PROXY_PORT" ]; then
-		    echo ${OPENVPN_PROXY_TYPE}-proxy $OPENVPN_PROXY $OPENVPN_PROXY_PORT >> /etc/client.conf
-		    echo ${OPENVPN_PROXY_TYPE}-proxy-retry >> /etc/client.conf
+		    echo ${OPENVPN_PROXY_TYPE}-proxy $OPENVPN_PROXY $OPENVPN_PROXY_PORT >> client.conf
+		    echo ${OPENVPN_PROXY_TYPE}-proxy-retry >> client.conf
 		fi
-		/bin/openvpn --daemon --config /etc/openvpn/client.conf --cd /etc/openvpn
+		/sbin/openvpn --daemon --config client.conf --cd /etc/openvpn
 	    fi
 	fi
     fi


### PR DESCRIPTION
OpenVPN is located in /sbin, not /bin.
Proxy directives should be written in /etc/openvpn/client.conf, not /etc/client.conf.
Also absolute paths are not necessary here, because we already cd'd into /etc/openvpn.