### PR TITLE
Update ocsinventory package to v1.5

### DIFF
--- a/ts/ports/components/ocsinventory/Pkgfile
+++ b/ts/ports/components/ocsinventory/Pkgfile
@@ -3,9 +3,9 @@
 # Maintainer: Donald A. Cupp Jr. (don cupp jr at ya hoo dot com)
 
 name=ocsinventory
-version=1.2
+version=1.5
 release=1
-source=(https://github.com/jackburton79/agent/archive/v1.2.tar.gz)
+source=(https://github.com/jackburton79/agent/archive/v1.5.tar.gz)
 
 build() {
 	cd agent-$version


### PR DESCRIPTION
List of major changes since v1.2:

- Changed method to generate the machine uuid for ocsinventory-ng:
If you were using an older release of the agent, this will create a duplicate entry.
This should be hopefully the last time this happens, as this method seems to be more reliable.
- Can connect to servers running on ports other than the standard 80
- Added ability to set a tag for the machine
- Get processors L2 cache size
- Improved inventory of memory slots: added slot number and description. Also: made it work in more cases
- Improved cpu identification: added number of cores, avoid adding an entry for each core of multi-core processors.
- Log everything through syslog(). To get output to console use the newly introduced -v (--verbose) commandline option
- Various fixes