### PR TITLE
OCSInventory agent: update to release 1.5

### DIFF
--- a/ts/ports/components/ocsinventory/Pkgfile
+++ b/ts/ports/components/ocsinventory/Pkgfile
@@ -3,13 +3,12 @@
 # Maintainer: Donald A. Cupp Jr. (don cupp jr at ya hoo dot com)
 
 name=ocsinventory
-version=git
+version=1.5
 release=1
-source=()
+source=(https://github.com/jackburton79/agent/archive/v1.5.tar.gz)
 
 build() {
-git clone https://github.com/jackburton79/agent.git
-	cd agent
+	cd agent-$version
 
 	make
 	mkdir -p $PKG/bin


### PR DESCRIPTION
Update OCSInventory to version 1,5 and don't point to master anymore, since it's an unstable branch