### PR TITLE
Build and Fixes client startup fix

### DIFF
--- a/ts/build/build.urls
+++ b/ts/build/build.urls
@@ -11,7 +11,7 @@ param chromeurl         https://dl.google.com/linux/direct/google-chrome-stable_
 #param chromeurl         http://mirror.pcbeta.com/google/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_41.0.2272.118-1_i386.deb
 param egalaxurl         http://www.eeti.com.tw/touch_driver/Linux/20141009/eGTouch_v2.5.4330.L-x.zip
 param vmviewpcoipurl    file://downloads/view.bundle
-param vmhorizonclient   https://download3.vmware.com/software/view/viewclients/CART18FQ3/VMware-Horizon-Client-4.6.0-6617224.x86.bundle
+param vmhorizonclienturl   https://download3.vmware.com/software/view/viewclients/CART18FQ3/VMware-Horizon-Client-4.6.0-6617224.x86.bundle
 param icaurl		file://downloads/linuxx86-13.3.0.344519.tar.gz
 param kioskurl		https://addons.cdn.mozilla.net/storage/public-staging/1659/r_kiosk-0.9.0-fx.xpi
 param javaurl		http://javadl.sun.com/webapps/download/AutoDL?BundleId=116019

--- a/ts/build/packages/vmhorizonclient/build/extra/lib/menu/vmview
+++ b/ts/build/packages/vmhorizonclient/build/extra/lib/menu/vmview
@@ -1,1 +1,1 @@
-package="vmview"; needs="x11"; menu="Connectivity"; title="VMware Horizon Client"; command="pkg window vmview"; nodesktop="true"
+package="vmview"; needs="x11"; menu="Connectivity"; title="VMware Horizon Client"; command="/bin/run_vmview --usbAutoConnectAtStartup=FALSE --usbAutoConnectOnInsert=FALSE"; nodesktop="true"


### PR DESCRIPTION
Added url to end of build.url param vmhorizonclient. Changed xfce4 menu to start Horizon Client without usb Auto Connect on insert and startup (required to prevent usb devices being automatically connected to virtual machines in vCenter).