### PR TITLE
remove file fix

### DIFF
--- a/ts/build/packages/vmhorizonclient/build/remove
+++ b/ts/build/packages/vmhorizonclient/build/remove
@@ -1,6 +1,6 @@
 #!/bin/bash
 # little script to build a thinstation package dir from vmware-view technical preview client
-INSTALLDIR=./packages/vmviewpcoip
+INSTALLDIR=./packages/vmhorizonclient
 
 rm -rf $INSTALLDIR/bin
 rm -rf $INSTALLDIR/lib
@@ -8,4 +8,3 @@ rm -rf $INSTALLDIR/etc
 rm -rf $INSTALLDIR/sbin
 rm $INSTALLDIR/build/license
 rm $INSTALLDIR/build/installed
-


### PR DESCRIPTION
Changed INSTALLDIR in remove file to point to the correct directory location for the vmhorizonclient package. otherwise the "build --removeall" causes errors for this package.