### PR TITLE
Syntax Error line 148 ?

### DIFF
--- a/ts/build/packages/ica/build/extra/bin/ica_receiver_config.sh
+++ b/ts/build/packages/ica/build/extra/bin/ica_receiver_config.sh
@@ -145,7 +145,7 @@ LOGGERTAG="ica_receiver_config.sh"
 		if [ $((ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL)) -gt 0 ]; then
 			logger --stderr --tag $LOGGERTAG "Adding ica_receiver_clear_credentials.sh with $((ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL)) minutes interval to crontab."
 			
-			if ! crontab -l | grep -q 'ic2a_receiver_clear_credentials.sh'; then
+			if ! crontab -l | grep -q 'ica_receiver_clear_credentials.sh'; then
 				echo "*/$((ICA_RECEIVER_CLEAR_CREDENTIALS_CHECK_INTERVAL)) * * * * /bin/ica_receiver_clear_credentials.sh" >> /tmp/crontab
 				crontab /tmp/crontab
 			fi


### PR DESCRIPTION
if ! crontab -l | grep -q 'ic2a_receiver_clear_credentials.sh'; then
change with
if ! crontab -l | grep -q 'ica_receiver_clear_credentials.sh'; then