### PR TITLE
citrix receiver 13.x

### DIFF
--- a/ts/build/packages/ica/build/finalize
+++ b/ts/build/packages/ica/build/finalize
@@ -1,6 +1,16 @@
 #ica 25
 chmod u+s /opt/Citrix/ICAClient/ctxusb
 
+#disable receiver connection bar
+sed -i '/ConnectionBar=*/c\ConnectionBar=0' /opt/Citrix/ICAClient/config/All_Regions.ini
+
+# Links appsrv.ini et wfclient.ini in permanent storage needed in ica.init 
+ln -s appsrv.template /opt/Citrix/ICAClient/config/appsrv.ini
+ln -s wfclient.template /opt/Citrix/ICAClient/config/wfclient.ini
+
+# Add Certificates from /etc/ssl/certs/ before CTX rehash CA certificates
+ln -s `find /etc/ssl/certs/ -type f` /opt/Citrix/ICAClient/keystore/cacerts/
+
 # Rehash all the CA certificates
 chmod 755 /opt/Citrix/ICAClient/keystore/cacerts/*
 /opt/Citrix/ICAClient/util/ctx_rehash


### PR DESCRIPTION
# Disable receiver connection bar
sed -i '/ConnectionBar=*/c\ConnectionBar=0' /opt/Citrix/ICAClient/config/All_Regions.ini

# Links appsrv.ini et wfclient.ini in permanent storage needed in ica.init 
ln -s appsrv.template /opt/Citrix/ICAClient/config/appsrv.ini
ln -s wfclient.template /opt/Citrix/ICAClient/config/wfclient.ini

# Add Certificates from /etc/ssl/certs/ before CTX rehash CA certificates
ln -s `find /etc/ssl/certs/ -type f` /opt/Citrix/ICAClient/keystore/cacerts/