### PR TITLE
Update build.urls

### DIFF
--- a/ts/build/build.urls
+++ b/ts/build/build.urls
@@ -5,7 +5,7 @@ param flash_lowmemurl   http://www.thinstation.org/download/flash/install_flash_
 param thinlincurl       http://www.cendio.com/downloads/clients/tl-latest-client-thinstation.tar.gz
 param thinlinc_nightlyurl http://www.cendio.com/downloads/nightly/tl-nightly-clients.zip
 param nxurl             http://thinstation.org/download/nx/nxclient-3.x-current.i386.tar.gz
-param 2xurl             http://www.2x.com/downloads/AppServer-LoadBalancer/2XClient.tar.bz2
+param 2xurl             http://download.parallels.com/ras/v16/16.2.0.19039/RASClient-16.2.19039_i386.tar.bz2
 param tarantellaurl     file://downloads/tnci3li.tar
 param chromeurl         https://dl.google.com/linux/direct/google-chrome-stable_current_i386.deb
 #param chromeurl         http://mirror.pcbeta.com/google/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_41.0.2272.118-1_i386.deb


### PR DESCRIPTION
Update 2xurl for 2XClient to RASClient
from: http://www.2x.com/downloads/AppServer-LoadBalancer/2XClient.tar.bz2
to: http://download.parallels.com/ras/v16/16.2.0.19039/RASClient-16.2.19039_i386.tar.bz2