### PR TITLE
Update source URL for firmware-ipw

### DIFF
--- a/ts/ports/binary-core/firmware-ipw/Pkgfile
+++ b/ts/ports/binary-core/firmware-ipw/Pkgfile
@@ -5,8 +5,8 @@
 name=firmware-ipw
 version=3.1
 release=1
-source=(http://pkgs.fedoraproject.org/repo/pkgs/ipw2100-firmware/ipw2100-fw-1.3.tgz/46aa75bcda1a00efa841f9707bbbd113/ipw2100-fw-1.3.tgz
-	http://pkgs.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-3.1.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-3.1.tgz)
+source=(http://firmware.openbsd.org/firmware-dist/ipw2100-fw-1.3.tgz
+	http://firmware.openbsd.org/firmware-dist/ipw2200-fw-3.1.tgz)
 
 build() {
 	mkdir -p $PKG/lib/firmware


### PR DESCRIPTION
> curl -I http://pkgs.fedoraproject.org/repo/pkgs/ipw2100-firmware/ipw2100-fw-1.3.tgz/46aa75bcda1a00efa841f9707bbbd113/ipw2100-fw-1.3.tgz
> HTTP/1.1 403 Forbidden
> Date: Mon, 12 Feb 2018 11:25:14 GMT
> Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_auth_gssapi/1.5.1 mod_wsgi/3.4 Python/2.7.5
> Content-Type: text/html; charset=iso-8859-1
> 

> curl -4 -I  http://pkgs.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-3.1.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-3.1.tgz
> HTTP/1.1 403 Forbidden
> Date: Mon, 12 Feb 2018 11:25:26 GMT
> Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_auth_gssapi/1.5.1 mod_wsgi/3.4 Python/2.7.5
> Content-Type: text/html; charset=iso-8859-1
> 