### PR TITLE
Update ocsinventory agent to version 1.6.3

### DIFF
--- a/ts/ports/components/ocsinventory/.md5sum
+++ b/ts/ports/components/ocsinventory/.md5sum
@@ -1,1 +1,1 @@
-ab86b8e0f002443030569404aaf77c75  v1.5.1.tar.gz
+def35d66ebccc701b2e5376f9dd94b7d  v1.6.3.tar.gz

--- a/ts/ports/components/ocsinventory/Pkgfile
+++ b/ts/ports/components/ocsinventory/Pkgfile
@@ -3,12 +3,12 @@
 # Maintainer: Donald A. Cupp Jr. (don cupp jr at ya hoo dot com)
 
 name=ocsinventory
-version=1.5.1
+version=1.6.3
 release=1
-source=(https://github.com/jackburton79/agent/archive/v$version.tar.gz)
+source=(https://github.com/jackburton79/ocs-agent/archive/v$version.tar.gz)
 
 build() {
-	cd agent-$version
+	cd ocs-agent-$version
 
 	make
 	mkdir -p $PKG/bin


### PR DESCRIPTION
Changes:

- Can now connect to a ocsinventory-ng server via HTTPS
- Can now connect to a ocsinventory-ng server which requires HTTP basic authentication
- Will retrieve more info when only lshw is available (and dmidecode is not)
- Fixed wrong memory inventory on machines which reports flash memory slots
- Fixed wrong memory inventory on machines with many GBytes of memory.
- Rewrote code which handles data from lshw to be more robust and clean
- Switch video card "name" and "chipset" fields, since they seem to be used this way in OCSInventory and glpi
- Add more fields to the inventory (computer type, etc)
- Added option --use-current-time-in-device-ID which allows you to use current date and time in device ID instead of the BIOS date.
- Added option --use-base-board-serial-number : There are some machines where the system serial number is empty/wrong. The base board serial number seems to be correct in that case. Could go away in one of the next releases, since on other machines, this is the same as the system serial number.


