### PR TITLE
New hostname script ?

### DIFF
--- a/ts/build/packages/autonet/lib/thinstation/system/hostname
+++ b/ts/build/packages/autonet/lib/thinstation/system/hostname
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. `dirname $0`/common
+#. `dirname $0`/common
 
 for adapter in `ls /var/log/net`; do
         . /var/log/net/$adapter


### PR DESCRIPTION
Hello,
The line 3 (. `dirname $0`/common) does not exist in previous version:
Ref: https://github.com/Thinstation/thinstation/blob/5.6-Stable/ts/build/packages/autonet/etc/init.d/hostname
Why are you add this in v6.1 ?
"hostname" script is Ok without this line for me.

Thank-you and best regards,
Stef.