### PR TITLE
Change alsa-project download urls to https instead of ftp

### DIFF
--- a/ts/ports/binary-core/firmware-alsa/Pkgfile
+++ b/ts/ports/binary-core/firmware-alsa/Pkgfile
@@ -5,7 +5,7 @@
 name=firmware-alsa
 version=1.0.29
 release=1
-source=(ftp://ftp.alsa-project.org/pub/firmware/alsa-firmware-$version.tar.bz2)
+source=(https://www.alsa-project.org/files/pub/firmware/alsa-firmware-$version.tar.bz2)
 
 build() {
 	cd alsa-firmware-$version

--- a/ts/ports/opt/alsa-lib/Pkgfile
+++ b/ts/ports/opt/alsa-lib/Pkgfile
@@ -6,7 +6,7 @@
 name=alsa-lib
 version=1.1.2
 release=1
-source=(ftp://ftp.alsa-project.org/pub/lib/$name-$version.tar.bz2)
+source=(https://www.alsa-project.org/files/pub/lib/$name-$version.tar.bz2)
 
 build() {
 	cd $name-$version

--- a/ts/ports/opt/alsa-plugins/Pkgfile
+++ b/ts/ports/opt/alsa-plugins/Pkgfile
@@ -6,7 +6,7 @@
 name=alsa-plugins
 version=1.1.1
 release=1
-source=(ftp://ftp.alsa-project.org/pub/plugins/$name-$version.tar.bz2)
+source=(https://www.alsa-project.org/files/pub/plugins/$name-$version.tar.bz2)
 
 build() {
     cd $name-$version

--- a/ts/ports/opt/alsa-utils/Pkgfile
+++ b/ts/ports/opt/alsa-utils/Pkgfile
@@ -6,7 +6,7 @@
 name=alsa-utils
 version=1.1.2
 release=1
-source=(ftp://ftp.alsa-project.org/pub/utils/$name-$version.tar.bz2 \
+source=(https://www.alsa-project.org/files/pub/utils/$name-$version.tar.bz2 \
 	rc.alsa)
 
 build() {


### PR DESCRIPTION
FTP is sometimes not reachable from behind a firewall. The libraries are also available via https.