### PR TITLE
Update build.conf.example

### DIFF
--- a/ts/build/build.conf.example
+++ b/ts/build/build.conf.example
@@ -423,3 +423,4 @@ param allfirmware	true		# Includes a lot of firmwares for live-cd s
 param earlymicrocode	false		# Builds microcode initramfs for early loading
 					# by kernel. Needs kernel with MICROCODE_EARLY=y.
 param blacklist snd-pcsp.ko
+#param mesa_3d disable			# The Mesa 3D Graphics Library disable


### PR DESCRIPTION
Usually 3D do not use in Thinstation, it is possible to exclude library for reduction of weight of the initrd file.