### PR TITLE
Update rdesktop security release 1.8.5

### DIFF
--- a/ts/ports/contrib/rdesktop/Pkgfile
+++ b/ts/ports/contrib/rdesktop/Pkgfile
@@ -4,9 +4,10 @@
 # Depends on: xorg-libx11
 
 name=rdesktop
-version=1.8.4
+version=1.8.5
 release=1
-source=(https://github.com/rdesktop/rdesktop/releases/download/v1.8.4/$name-$version.tar.gz)
+source=(https://github.com/rdesktop/rdesktop/releases/download/v1.8.5/$name-$version.tar.gz)
+#source=(https://github.com/rdesktop/rdesktop/releases/download/v1.8.4/$name-$version.tar.gz)
 #source=(http://download.sourceforge.net/rdesktop/$name-$version.tar.gz)
 build(){
 	cd $name-$version


### PR DESCRIPTION
https://github.com/rdesktop/rdesktop/releases/tag/v1.8.5

This is a security release to address various buffer overflow and overrun issues in the rdesktop protocol handling. rdesktop will now detect any attempts to access invalid areas and refuse to continue. Users are adviced to upgrade as soon as possible.

A big thank you to Kaspersky Lab and National Cyber Security Centre for identifying these issues.