### PR TITLE
Added if statement for proxy check

### DIFF
--- a/ts/build/packages/installer/bin/installer
+++ b/ts/build/packages/installer/bin/installer
@@ -407,7 +407,10 @@ if is_enabled $INSTALLER_DEV || is_enabled $INSTALLER_MEM_CHECK ; then
 	mem_check
 fi
 
-proxy_check
+if is_enabled $INSTALLER_DEV || is_enabled $INSTALLER_PROXY_CHECK ; then
+	proxy_check
+fi
+
 disk_select
 
 if is_enabled $INSTALLER_DEV ; then


### PR DESCRIPTION
This will only be used for the dev builder install and in rare occasions for people using external repos to host their custom images. Being able to disable this will benefit users who host images internally that do not need to check their internet connection.