### PR TITLE
Remove mime associations to the old ICA plugin

### DIFF
--- a/ts/build/packages/ica/build/extra/etc/init.d/ica-init
+++ b/ts/build/packages/ica/build/extra/etc/init.d/ica-init
@@ -43,14 +43,6 @@ if ! pkg_initialized $PACKAGE; then
    chmod u+w $ICA_CACHE
  fi
 
- # Set file Permissions and links to those of a normal ICA install
- if [ ! -e $HOME/.mailcap ] || [ "`grep -c -E ICA $HOME/.mailcap`" == "0" ] ; then
-        echo "application/x-ica; $ICA_ROOT/wfica.sh %s; x-mozilla-flags=plugin:Citrix ICA Client" >> $HOME/.mailcap
- fi
- if [ ! -e $HOME/.mime.types ] || [ "`grep -c -E ICA $HOME/.mime.types`" == "0" ] ; then
-        echo 'type=application/x-ica exts=ica desc="Citrix ICA"' >> $HOME/.mime.types
- fi
-
  chmod u+s $ICA_ROOT/ctxusb
 
  # Checks for pre-existing files, from permanent storage

--- a/ts/build/packages/ica/build/finalize
+++ b/ts/build/packages/ica/build/finalize
@@ -10,7 +10,7 @@ if is_enabled $ICA_DISABLE_START_CONFIG; then
 fi
 
 if [ ! -e /etc/xdg/mimeapps.list ]; then
-	echo "[Default Applications]" > /etc/xdg/mimeapss.list
+	echo "[Default Applications]" > /etc/xdg/mimeapps.list
 fi
 cat << 'EOF' >> /etc/xdg/mimeapps.list
 application/x-ica=wfica.desktop;


### PR DESCRIPTION
I think this code in ica-init is randomly blocking Firefox from doing the proper mime association to launch Citrix Receiver with .ica files.
If we don't think we need to do backward compatibility with old Firefox with plugin support and old Citrix that have said plugin, we should simply delete this code as per this patch.
Otherwise, it appears that the Citrix mime package in Receivers released after the FF plugin removal handle the mime association correctly.  We haven't determined the pattern for why this sometimes takes precedence and other times the mailcap takes precedence, but either way the old code was a problem.
Also found a typo in the backup mime association.