### PR TITLE
Fix proxy and freerdp initializations; Fix non-SB refind build targets

### DIFF
--- a/ts/build/build
+++ b/ts/build/build
@@ -2283,7 +2283,7 @@ refind_copy_files()
 	done
 
 #	sys_copy $refdir/refind_ia32.efi $EFIDIR/bootia32.efi
-	sys_copy $refdir/refind_x64.efi $EFIDIR/loader.efi
+	sys_copy $refdir/refind_x64.efi $EFIDIR/bootx64.efi
 
 	for file in `find $configdir -type f |sed -e "s|$configdir||g"`; do
 		sys_copy ${configdir}${file} "$EFIDIR/$file"
@@ -2520,6 +2520,8 @@ if [ -z "$NOIMAGES" ]; then
 				LM=4
 
 				CONFIGFILE=refind.conf
+				refind_copy_files
+				mv $ESP/EFI/BOOT/bootx64.efi $ESP/EFI/BOOT/loader.efi
                         #        sys_copy /boot/efi/EFI/fedora/shimx64.efi $ESP/EFI/BOOT/bootx64.efi
 				sys_copy /usr/lib/prebootloader/KeyTool.efi $ESP/EFI/BOOT/KeyTool.efi
 				sys_copy /boot/efi/EFI/ThinStation/shimx64.efi $ESP/EFI/BOOT/bootx64.efi
@@ -2530,7 +2532,6 @@ if [ -z "$NOIMAGES" ]; then
 				sys_copy /ts/certs/ThinStation-KEK-CA.cer $ESP/ThinStation-KEK-CA.cer
 				sys_copy /ts/certs/ThinStation-SB-UEFI-CA.cer $ESP/ThinStation-SB-UEFI-CA.cer
 				sys_copy /ts/certs/ThinStation-SB-UEFI-Signing.cer $ESP/ThinStation-SB-UEFI-Signing.cer
-				refind_copy_files
 				add_overlay
 				add_image efi
 				wrap_efi

--- a/ts/build/packages/base/etc/thinstation.functions
+++ b/ts/build/packages/base/etc/thinstation.functions
@@ -649,11 +649,11 @@ dconf_proxy_configure ()
 			unset IFS
 			hosts="[`echo $hosts |cut -c3-`]"
 
-			dconf write /org/gnome/system/proxy/ignore-hosts "$hosts"
+			dconf write /system/proxy/ignore-hosts "$hosts"
 		fi
 	if [ -n "$PROXY_HOST" ] && [ -n "$PROXY_PORT" ] ; then
-			dconf write /org/gnome/system/proxy/http/host "'$PROXY_HOST'"
-			dconf write /org/gnome/system/proxy/http/port "$PROXY_PORT"
+			dconf write /system/proxy/http/host "'$PROXY_HOST'"
+			dconf write /system/proxy/http/port "$PROXY_PORT"
 
 			if [ -z "$PROXY_USE_SAME$PROXY_SECURE_HOST$PROXY_SOCKS_HOST$PROXY_FTP_HOST" ]; then
 				PROXY_USE_SAME=true
@@ -670,30 +670,30 @@ dconf_proxy_configure ()
 		fi
 
 		if [ -n "$PROXY_SECURE_HOST" ] && [ -n "$PROXY_SECURE_PORT" ]; then
-			dconf write /org/gnome/system/proxy/https/host "'$PROXY_SECURE_HOST'"
-			dconf write /org/gnome/system/proxy/https/port "$PROXY_SECURE_PORT"
+			dconf write /system/proxy/https/host "'$PROXY_SECURE_HOST'"
+			dconf write /system/proxy/https/port "$PROXY_SECURE_PORT"
 		fi
 		if [ -n "$PROXY_SOCKS_HOST" ] && [ -n "$PROXY_SOCKS_PORT" ]; then
-			dconf write /org/gnome/system/proxy/socks/host "'$PROXY_SOCKS_HOST'"
-			dconf write /org/gnome/system/proxy/socks/port "$PROXY_SOCKS_PORT"
+			dconf write /system/proxy/socks/host "'$PROXY_SOCKS_HOST'"
+			dconf write /system/proxy/socks/port "$PROXY_SOCKS_PORT"
 		fi
 		if [ -n "$PROXY_FTP_HOST" ] && [ -n "$PROXY_FTP_PORT" ]; then
-			dconf write /org/gnome/system/proxy/ftp/host "'$PROXY_FTP_HOST'"
-			dconf write /org/gnome/system/proxy/ftp/port "$PROXY_FTP_PORT"
+			dconf write /system/proxy/ftp/host "'$PROXY_FTP_HOST'"
+			dconf write /system/proxy/ftp/port "$PROXY_FTP_PORT"
 		fi
 		if [ -n "$PROXY_AUTOCONFIG" ]; then
-			dconf write /org/gnome/system/proxy/autoconfig-url "'$PROXY_AUTOCONFIG'"
+			dconf write /system/proxy/autoconfig-url "'$PROXY_AUTOCONFIG'"
 		fi
 
 		if [ "$PROXY_MODE" == "none" ] \
 		|| [ -z "$PROXY_MODE$PROXY_HOST$PROXY_SECURE_HOST$PROXY_FTP_HOST$PROXY_SOCKS_HOST$PROXY_AUTOCONFIG" ]; then
-			dconf write /org/gnome/system/proxy/mode "'none'"
+			dconf write /system/proxy/mode "'none'"
 		elif [ "$PROXY_MODE" == "auto" ] \
 		|| [ -z "$PROXY_MODE" ] \
 		&& [ -n "$PROXY_AUTOCONFIG" ]; then
-			dconf write /org/gnome/system/proxy/mode "'auto'"
+			dconf write /system/proxy/mode "'auto'"
 		else
-			dconf write /org/gnome/system/proxy/mode "'manual'"
+			dconf write /system/proxy/mode "'manual'"
 		fi
 	fi
 }

--- a/ts/build/packages/freerdp/build/extra/etc/init.d/freerdp-init
+++ b/ts/build/packages/freerdp/build/extra/etc/init.d/freerdp-init
@@ -5,14 +5,14 @@
 if ! pkg_initialized $PACKAGE; then
 	pkg_set_init_flag $PACKAGE
 
-#	if is_disabled "$FREERDP_NLA"; then
-#		FRDPOPTIONS="$FRDPOPTIONS -sec-nla"
-#	fi
+	if [ -n "$FREERDP_NLA" ] && is_disabled "$FREERDP_NLA"; then
+		FRDPOPTIONS="$FRDPOPTIONS -sec-nla"
+	fi
 
-#	if is_disabled "$FREERDP_GETUSER"; then
-#		rm -f /etc/cmd/freerdp.getuser
-#		rm -f /etc/cmd/freerdp.getpass
-#	fi
+	if [ -n "$FREERDP_GETUSER" ] && is_disabled "$FREERDP_GETUSER"; then
+		rm -f /etc/cmd/freerdp.getuser
+		rm -f /etc/cmd/freerdp.getpass
+	fi
 
 	if [ -n "$FREERDP_SMARTCARD" ]; then
 		FRDPOPTIONS="$FRDPOPTIONS /smartcard:$FREERDP_SMARTCARD"


### PR DESCRIPTION
Applied some fixes to freerdp and proxy setup based on testing
I also found that the refind target was broken and modified refind and refind-iso to match systemd-boot and systemd-boot-iso