### PR TITLE
Add "realtek" module

### DIFF
--- a/ts/build/machine/intel_nuc7jy/module.list
+++ b/ts/build/machine/intel_nuc7jy/module.list
@@ -73,6 +73,7 @@ module bluetooth
 module pinctrl-geminilake
 module ecdh_generic
 module i915
+module realtek
 module r8169
 module pata_ali
 module iwlwifi


### PR DESCRIPTION
The `r8169` module require the `realtek` module to work properly