### PR TITLE
Update setup-chroot: double tick to early

### DIFF
--- a/setup-chroot
+++ b/setup-chroot
@@ -214,10 +214,11 @@ secure_keys()
 do_unmounts()
 {
 	for mount in dev/pts dev tmp proc sys run/pcscd run/user/0 run/user/$SUDO_UID; do
-		fuser -kv "$PWD"/$mount > /dev/null 2>&1
-		while mounted $mount ; do
+		umount -l $mount
+		if [ $? -ne 0 ] ; then
+			fuser -kv "$PWD/$mount" > /dev/null 2>&1
 			umount -l $mount
-		done
+		fi
 	done
 }
 


### PR DESCRIPTION
* Line 219: second double tick probably on wrong place.
* With problem of line 219, fuser takes often 20 seconds (Ubuntu 18.04, ZFS) to finish per mountpoint (8 mountpoints >> 160 seconds to leave 'setup-chroot').
* Browser Google Chrome  and Brave crashes when fireing `fuser -kv "$PWD"/$mount` (independent of fixed line 219) - wonder why?