### PR TITLE
Probably outdated: 'Needs userauto package.'

### DIFF
--- a/ts/build/build.conf.example
+++ b/ts/build/build.conf.example
@@ -345,7 +345,7 @@ package fonts-TTF-noto
 param fastboot       true				# Mangles the filesystem a special way as to improve boot speed and reduce
 							# memory utilization. Cool/Dangerous . Harder to dubug other packages. (Finishing Touch)
 							# Set to 'true' to enable or 'lotsofmem' for slightly slower booting but no squash lag on app launch.
-param tsuser         tsuser                            # Name of the user that thinstation will run as. Needs userauto package.
+param tsuser         tsuser                             # Name of the user that thinstation will run as. 
 param tsuserpasswd   pleasechangeme			# Do Change! Console/telnet password for non-root
 
 param rootpasswd     pleasechangeme			# Do Change!  Console/telnet password for root


### PR DESCRIPTION
The comment 'Needs userauto package.' is probably outdated. I've found no named package. Setting 'tsuser' works even without that package. Building TS with this package reports an error.