### PR TITLE
Update freerdp

### DIFF
--- a/ts/ports/opt/freerdp/Pkgfile
+++ b/ts/ports/opt/freerdp/Pkgfile
@@ -5,7 +5,7 @@
 
 name=freerdp
 version=2.0
-release=2.6.1
+release=2.7.0
 #source=(freerdp-2.0.0-tprdp.patch)
 
 build() {


### PR DESCRIPTION
Update to version 2.7.0 
https://github.com/FreeRDP/FreeRDP/releases/tag/2.7.0
Please rebuild the package and update .fooprint and .md5sum